### PR TITLE
feat: configure cancancan to handle system permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ gem "devise"
 gem "devise_token_auth"
 gem "omniauth", "~> 2.1"
 
+# Authorization
+gem 'cancancan'
+
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       racc
     builder (3.3.0)
     byebug (11.1.3)
+    cancancan (3.6.1)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -332,6 +333,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   byebug
+  cancancan
   database_cleaner
   debug
   devise

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+      if user.admin?
+        can :manage, :all
+      end
+  end
+end


### PR DESCRIPTION
## Motivação

Em nosso sistema de anúncio, irá precisar ter um controle de permissão de recursos, por exemplo, um usuário só pode gerenciar os anúncios deles. Temos que adicionar algum mecanismo que gerencie as permissões de cada usuário com os recursos do sistema.

## Proposta de solução

Adicionar as configurações iniciais da lib cancancan para depois utilizar no sistema.

## Testes

Print/Video

## Links Importante

- Trello: [Configurar Biblioteca de Permissões](https://trello.com/c/jVDGc1Wk/58-configurar-biblioteca-de-permiss%C3%B5es)