### PR TITLE
Expose authentication headers

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,6 +10,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins "*"
 
     resource "*",
+      expose: %w[Authorization Uid Client Access-Token],
       headers: :any,
       methods: %i[get post put patch delete options head]
   end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -10,7 +10,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     origins "*"
 
     resource "*",
-      expose: %w[Authorization Uid Client Access-Token],
+      expose: %w[Authorization Uid Client Access-Token Expiry],
       headers: :any,
       methods: %i[get post put patch delete options head]
   end


### PR DESCRIPTION
## Motivação

Possibilitar a obtenção dos headers de autenticação no front-end

## Proposta de solução

Expor os headers na configuração de CORS