### PR TITLE
feat: remove current password validation for user updates

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -35,7 +35,7 @@ DeviseTokenAuth.setup do |config|
   # Uncomment to enforce current_password param to be checked before all
   # attribute updates. Set it to :password if you want it to be checked only if
   # password is updated.
-  config.check_current_password_before_update = :attributes
+  # config.check_current_password_before_update = :attributes
 
   # By default we will use callbacks for single omniauth.
   # It depends on fields like email, provider and uid.


### PR DESCRIPTION
## Motivação

Remover a necessidade do usuário adicionar a sua senha atual para altera suas informações

## Proposta de solução

Propomos a seguinte solução ...

## Testes

Print/Video

## Links Importante

- Trello: [Nome da task](link_da_task)